### PR TITLE
Upgrading strata.search function to the new Solr search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,13 @@ JavaScript Library to interact with the Red Hat Customer Portal API
 Requires [jQuery](https://jquery.org/) and [jsUri](https://github.com/derek-watson/jsUri)
 
 See test/js/stratajs-driver.js for usage examples
+
+### Testing Locally
+
+Using Apache or Nginx to proxy / to 8080 or any port of your choosing.
+
+Edit `/etc/hosts` to point foo.redhat.com to localhost.
+
+In the stratajs directory start `python -m SimpleHTTPServer 8080`
+
+In your browser go to: https://foo.redhat.com/test/index.html

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "stratajs",
   "description": "JavaScript Library to interact with the Red Hat Customer Portal API",
-  "version": "1.4.14",
+  "version": "1.4.15",
   "main": "strata.js",
   "repository": {
     "type": "git",

--- a/strata.js
+++ b/strata.js
@@ -2037,10 +2037,10 @@
             success: function (response) {
                 if (chain && response && response.response && response.response.docs !== undefined) {
                     response.response.docs.forEach(function (entry) {
-                        strata.utils.getURI(entry.uri, entry.resource_type, onSuccess, onFailure);
+                        strata.utils.getURI(entry.uri, entry.documentKind, onSuccess, onFailure);
                     });
                 } else if (response && response.response && response.response.docs !== undefined) {
-                    onSuccess(response.search_result);
+                    onSuccess(response.response.docs);
                 } else {
                     onSuccess([]);
                 }

--- a/strata.js
+++ b/strata.js
@@ -2027,7 +2027,6 @@
         
         var searchStrata = $.extend({}, baseAjaxParams, {
             headers: {
-                'X-Omit': 'WWW-Authenticate',
                 accept: 'application/vnd.redhat.solr+json'
             },
             url: strataHostname.clone().setPath('/rs/search')

--- a/strata.js
+++ b/strata.js
@@ -2035,11 +2035,11 @@
                 .addQueryParam('enableElevation', 'true') // Enable hand picked solutions
                 .addQueryParam('rows', rows),
             success: function (response) {
-                if (chain && response && response.response.docs !== undefined) {
+                if (chain && response && response.response && response.response.docs !== undefined) {
                     response.response.docs.forEach(function (entry) {
                         strata.utils.getURI(entry.uri, entry.resource_type, onSuccess, onFailure);
                     });
-                } else if (response && response.response.docs !== undefined) {
+                } else if (response && response.response && response.response.docs !== undefined) {
                     onSuccess(response.search_result);
                 } else {
                     onSuccess([]);

--- a/test/js/strata-driver.js
+++ b/test/js/strata-driver.js
@@ -284,6 +284,15 @@ Caused by: java.net.ConnectException: Connection refused \n\
         11,
         true
     );
+    
+    //Returns an array of Articles and Solutions
+    strata.search("mod_cluster 503",
+        function (docs) {
+            console.log(docs.length + " solutions/articles found for search 'mod_cluster 503'");
+        },
+        onFailure,
+        10
+    );
 
     var filter = new strata.CaseFilter();
     filter.id = "#########";


### PR DESCRIPTION
The new endpoint accepts `application/vnd.redhat.solr+json` and requires q= instead of keyword=.  The new endpoint also allows for handpicked solutions via enableElevation.  Other various changes relating to the new endpoint as well.