### PR TITLE
Overiding the default "json: dataType in bookmark API

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "stratajs",
   "description": "JavaScript Library to interact with the Red Hat Customer Portal API",
-  "version": "1.4.22",
+  "version": "1.4.23",
   "main": "strata.js",
   "repository": {
     "type": "git",

--- a/strata.js
+++ b/strata.js
@@ -1977,6 +1977,7 @@
             type: 'POST',
             method: 'POST',
             contentType: 'application/json',
+            dataType: "text",
             success: onSuccess,
             error: function (xhr, response, status) {
                 onFailure('Error ' + xhr.status + ' ' + xhr.statusText, xhr, response, status);
@@ -1998,6 +1999,7 @@
             url: url,
             type: 'DELETE',
             method: 'DELETE',
+            dataType: "text",
             success: onSuccess,
             error: function (xhr, response, status) {
                 onFailure('Error ' + xhr.status + ' ' + xhr.statusText, xhr, response, status);


### PR DESCRIPTION
Some recent jQuery changes caused the requests to break, as it tries to parse the empty responses as JSONs, changing data type to "text" fixes it.

@vrathee @gandhikeyur Please review,