### PR TITLE
Fix path.search is not a function bug

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "stratajs",
   "description": "JavaScript Library to interact with the Red Hat Customer Portal API",
-  "version": "1.4.28",
+  "version": "1.4.29",
   "main": "strata.js",
   "repository": {
     "type": "git",

--- a/strata.js
+++ b/strata.js
@@ -238,8 +238,9 @@
     }
 
     //Function to test whether we've been passed a URL or just a string/ID
-    function isUrl(path) {
-        return path.search(/^http/) >= 0;
+    //regex from https://github.com/segmentio/is-url/blob/master/index.js
+    function isUrl(string) {
+        return /^(?:\w+:)?\/\/([^\s\.]+\.\S{2}|localhost[\:?\d]*)\S*$/.test(string);
     }
 
     var XML_CHAR_MAP = {
@@ -1295,7 +1296,7 @@
                             onProgress(percentComplete);
                         }
                     }, false);
-                }                
+                }
                return xhr;
             },
             url: url,


### PR DESCRIPTION
when `path` is null, it will throw error. using regex will be better
regex from https://github.com/segmentio/is-url/blob/master/index.js