### PR TITLE
pcm-5386 fetching recommendations of all types except Documentation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "stratajs",
   "description": "JavaScript Library to interact with the Red Hat Customer Portal API",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "main": "strata.js",
   "repository": {
     "type": "git",

--- a/strata.js
+++ b/strata.js
@@ -452,6 +452,7 @@
             .addQueryParam('rows', String(limit))
             .addQueryParam('start', String(start)) // jsUri fubar's 0, it doesn't add it as a number, must force it to a string to be safe
             .addQueryParam('fl', '*,score')
+            .addQueryParam('fq', '-documentKind:Documentation')
             .addQueryParam('fq', '-internalTags:helper_solution');
 
         if (highlight) {


### PR DESCRIPTION
@engineersamuel @renujhamtani Please review.

As per the comment in https://projects.engineering.redhat.com/browse/PCM-5386 , removing documentType Documentation while fetching recommendations from Hydra.